### PR TITLE
ECMAScript bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ var FastClone = {
                 var value = source[key];
                 var path = base + '.' + key; // current key path
 
-                if (deep && typeof value == 'object') {
+                if (deep && typeof value == 'object' && value !== null) {
                     keysMap += FastClone._getKeyMap(value, deep, path, index);
                 } else {
                     keysMap += 'this' + path + ' = src' + path + ';';


### PR DESCRIPTION
Due to ECMAScript bug, typeof null is object. 
So, you will get {} instead null as result.